### PR TITLE
make #headers public on CsvBuilder

### DIFF
--- a/lib/as_csv/csv_builder.rb
+++ b/lib/as_csv/csv_builder.rb
@@ -15,14 +15,14 @@ module AsCSV
       rows.collect { |row| CSV.generate_line(row, **csv_options) }.join
     end
 
+    def headers
+      @headers ||= csv_hashes.collect(&:keys).flatten.uniq
+    end
+
     private
 
       def rows
         @rows ||= [headers] + data_rows
-      end
-
-      def headers
-        @headers ||= csv_hashes.collect(&:keys).flatten.uniq
       end
 
       def data_rows

--- a/spec/lib/csv_builder_spec.rb
+++ b/spec/lib/csv_builder_spec.rb
@@ -39,7 +39,7 @@ describe AsCSV::CSVBuilder do
       end
     end
 
-    context 'with hetreogenous records' do
+    context 'with heterogeneous records' do
       let(:records) do
         2.times.map do |i|
           double(:foo, :as_csv => {


### PR DESCRIPTION
we have a use case where we'd like to generate only the headers. in order to generate the headers correctly we do need to look at all rows and collect/uniq them, why is why I am adding it to csv_builder

please let me know feedback